### PR TITLE
Don't write above the current terminal

### DIFF
--- a/examples/buzzwords.js
+++ b/examples/buzzwords.js
@@ -18,7 +18,7 @@ function delay(ms) {
 function createRandomTask() {
 
     var task = observatory
-        .add(faker.company.bs());
+        .add(faker.Company.bs());
     var percent = 0;
 
     function download () {
@@ -42,8 +42,9 @@ function createRandomTask() {
     }
 
     function done() {
+        var noun = faker.Company.bs().split(' ')[2];
         task.done()
-            .details('https://github.com/' + faker.internet.domainWord() + '/' + faker.company.bsNoun());
+            .details('https://github.com/' + faker.Internet.domainWord() + '/' + noun);
 
         return q.defer().promise;
     }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -10,7 +10,7 @@ var states = {
 var defaultSettings = {
     width: 55,
     prefix: ' ⫸  ',
-    write: process.stdout.write.bind(process.stdout),
+    stream: process.stdout,
     formatStatus: function(statusLabel, state) {
 
         if (!statusLabel) {

--- a/lib/observatory.js
+++ b/lib/observatory.js
@@ -33,9 +33,12 @@ function createTask(description) {
     }
 
     function update() {
+        var stream = out.getStream();
         var output = task.render();
         var change = currentLine - task.line;
-        if (change >= out.stream.rows) return task;
+        if (typeof stream.rows === 'number' && change >= stream.rows) {
+            return task;
+        }
         out.write(position.cursorUp(change));
         out.write(output);
         out.write(position.cursorDown(change - (out.height(output) - 1)));

--- a/lib/observatory.js
+++ b/lib/observatory.js
@@ -35,6 +35,7 @@ function createTask(description) {
     function update() {
         var output = task.render();
         var change = currentLine - task.line;
+        if (change >= out.stream.rows) return task;
         out.write(position.cursorUp(change));
         out.write(output);
         out.write(position.cursorDown(change - (out.height(output) - 1)));

--- a/lib/out.js
+++ b/lib/out.js
@@ -3,7 +3,6 @@
 var chalk = require('chalk');
 var OS = require('os');
 var settings = require('./settings');
-var stream = settings.getStream();
 
 /**
  * figure out how many lines a string of text will use
@@ -22,9 +21,14 @@ function writeln(currentLine, text) {
 }
 
 function write(text) {
+    var stream = getStream();
     if (stream && stream.write) {
         stream.write(text);
     }
+}
+
+function getStream() {
+    return settings.getStream();
 }
 
 function ln(text) {
@@ -41,5 +45,5 @@ module.exports = {
     write: write,
     ln: ln,
     padding: padding,
-    stream: stream
+    getStream: getStream
 };

--- a/lib/out.js
+++ b/lib/out.js
@@ -3,6 +3,7 @@
 var chalk = require('chalk');
 var OS = require('os');
 var settings = require('./settings');
+var stream = settings.getStream();
 
 /**
  * figure out how many lines a string of text will use
@@ -21,8 +22,8 @@ function writeln(currentLine, text) {
 }
 
 function write(text) {
-    if (settings.write) {
-        settings.write(text);
+    if (stream && stream.write) {
+        stream.write(text);
     }
 }
 
@@ -39,5 +40,6 @@ module.exports = {
     writeln: writeln,
     write: write,
     ln: ln,
-    padding: padding
+    padding: padding,
+    stream: stream
 };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -30,6 +30,9 @@ function formatStatus (statusLabel, state) {
     return settings.formatStatus(statusLabel, state);
 }
 
+function getStream(){
+    return settings.stream;
+}
 
 settings = setSettings();
 
@@ -38,5 +41,6 @@ module.exports = {
     width: width,
     prefix: prefix,
     write: write,
-    formatStatus: formatStatus
+    formatStatus: formatStatus,
+    getStream: getStream
 };

--- a/test/observatory.test.js
+++ b/test/observatory.test.js
@@ -9,7 +9,7 @@ describe('observatory', function () {
     describe('addTask', function () {
 
         it('addTask simple', function () {
-            var label = Faker.company.catchPhrase();
+            var label = Faker.Company.catchPhrase();
             var task = observatory.add(label);
             expect(task).to.be.an.object;
         });
@@ -19,18 +19,18 @@ describe('observatory', function () {
     describe('workflow', function () {
 
         it('create task', function () {
-            var label = Faker.company.catchPhrase();
+            var label = Faker.Company.catchPhrase();
             var task = observatory.add(label);
         });
 
         it('done', function () {
-            var label = Faker.company.catchPhrase();
+            var label = Faker.Company.catchPhrase();
             var task = observatory.add(label);
             task.done();
         });
 
         it('fail', function () {
-            var label = Faker.company.catchPhrase();
+            var label = Faker.Company.catchPhrase();
             var task = observatory.add(label);
             task.fail();
         });
@@ -41,9 +41,9 @@ describe('observatory', function () {
     describe('multiple tasks', function () {
 
         it('', function () {
-            var task1 = observatory.add(Faker.company.catchPhrase());
-            var task2 = observatory.add(Faker.company.catchPhrase());
-            var task3 = observatory.add(Faker.company.catchPhrase());
+            var task1 = observatory.add(Faker.Company.catchPhrase());
+            var task2 = observatory.add(Faker.Company.catchPhrase());
+            var task3 = observatory.add(Faker.Company.catchPhrase());
             task1.done();
             task2.done();
             task3.done();
@@ -53,7 +53,7 @@ describe('observatory', function () {
     describe('change status text', function () {
 
         it('', function () {
-            var task = observatory.add(Faker.company.catchPhrase());
+            var task = observatory.add(Faker.Company.catchPhrase());
             task.status('started')
                 .status('download files')
                 .status('read files')

--- a/test/observatory.test.js
+++ b/test/observatory.test.js
@@ -3,7 +3,9 @@ var expect = require('chai').expect;
 var observatory = require('../lib/observatory.js');
 var Faker = require('faker');
 
-observatory.settings({write: function(text){return text;    }});
+observatory.settings({
+    stream: { write: function () {} }
+});
 
 describe('observatory', function () {
     describe('addTask', function () {


### PR DESCRIPTION
This prevents the cursor from moving up when it can't.

Also, this fixes faker support since it's been broken at some point.