### PR TITLE
Remove global install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Instead of just logging long running tasks to the console, give your users a sim
 ## Installation
 
 ```bash
-$ npm -g install observatory
+$ npm install observatory
 ```
 
 ## Examples


### PR DESCRIPTION
The README has you install `observatory` globally. This seemed incorrect to me, but I might be missing something. Feel free to close if wrong.

Thanks!