### PR TITLE
Remove lodash dependency

### DIFF
--- a/lib/observatory.js
+++ b/lib/observatory.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var position = require('ansi-escapes');
-var _ = require('lodash');
 
 var constants = require('./constants');
 
@@ -72,7 +71,7 @@ function createTask(description) {
         return task.update();
     }
 
-    _.merge(task, {
+    Object.assign(task, {
         render: render,
         update: update,
         setStatusLabel: setStatusLabel,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,17 +1,16 @@
 'use strict';
 
 var constants = require('./constants');
-var _ = require('lodash');
 
 var settings = {};
 
 function setSettings(options) {
 
     if (!options) {
-        return _.merge(constants.defaultSettings, {});
+        return Object.assign(constants.defaultSettings, {});
     }
 
-    return _.merge(settings, options);
+    return Object.assign(settings, options);
 }
 
 function width() {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   ],
   "dependencies": {
     "ansi-escapes": "^1.1.0",
-    "chalk": "^1.1.1",
-    "lodash": "^3.10.1"
+    "chalk": "^1.1.1"
   }
 }


### PR DESCRIPTION
Trying to trim up some dependencies for https://github.com/bustlelabs/shep and I think it is pretty safe to remove the lodash dependency here. If not wanted, I can also upgrade lodash to 4.0 or just pull in `lodash.merge`
