### PR TITLE
Remove lodash dep in favor of object-assign

### DIFF
--- a/lib/observatory.js
+++ b/lib/observatory.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var position = require('ansi-escapes');
-var _ = require('lodash');
+var assign = require('object-assign');
 
 var constants = require('./constants');
 
@@ -72,7 +72,7 @@ function createTask(description) {
         return task.update();
     }
 
-    _.merge(task, {
+    assign(task, {
         render: render,
         update: update,
         setStatusLabel: setStatusLabel,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,17 +1,17 @@
 'use strict';
 
 var constants = require('./constants');
-var _ = require('lodash');
+var assign = require('object-assign');
 
 var settings = {};
 
 function setSettings(options) {
 
     if (!options) {
-        return _.merge(constants.defaultSettings, {});
+        return assign(constants.defaultSettings, {});
     }
 
-    return _.merge(settings, options);
+    return assign(settings, options);
 }
 
 function width() {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "dependencies": {
     "ansi-escapes": "^1.1.0",
     "chalk": "^1.1.1",
-    "lodash": "^3.10.1"
+    "object-assign": "^4.1.0"
   }
 }


### PR DESCRIPTION
This is an alternative to https://github.com/dylang/observatory/pull/14 that should pass tests on node < 4.0
